### PR TITLE
Fix scroll logic for overscroll on safari

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -28,7 +28,9 @@ const Header: FC<IThemeProps> = ({ theme, toggleTheme }) => {
     let lastScrollY = window.scrollY;
 
     window.addEventListener("scroll", () => {
-      if (lastScrollY < window.scrollY) {
+      if (window.scrollY === 0 || window.scrollY < 0) {
+        setShowNav(true);
+      } else if (lastScrollY < window.scrollY) {
         setShowNav(false);
       } else {
         setShowNav(true);


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Update the condition to show nav when at the top of the screen for safari

Closes #142 